### PR TITLE
Added mailing_list page.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
 			<div class="col-12 col-sm-4">
 				<p>Help</p>
 				<p><a href="{{ "/search" | prepend: site.baseurl }}">Search</a></p>
-				<p><a href="{{ "/mailing-lists" | prepend: site.baseurl }}">Mailing Lists</a></p>
+				<p><a href="{{ "/mailing_lists" | prepend: site.baseurl }}">Mailing Lists</a></p>
 				<p><a href="{{ site.sourceurl }}">Website Source</a></p>
 			<br></div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
 			<div class="col-12 col-sm-4">
 				<p>Help</p>
 				<p><a href="{{ "/search" | prepend: site.baseurl }}">Search</a></p>
-				<p><a href="#">Mailing Lists</a></p>
+				<p><a href="{{ "/mailing-lists" | prepend: site.baseurl }}">Mailing Lists</a></p>
 				<p><a href="{{ site.sourceurl }}">Website Source</a></p>
 			<br></div>
 

--- a/_pages/mailing_list.md
+++ b/_pages/mailing_list.md
@@ -1,7 +1,7 @@
 ---
 layout: toc
 title: Mailing Lists
-permalink: /mailing-lists/
+permalink: /mailing_lists/
 ---
 
 There are two mailing lists for gem5:

--- a/_pages/mailing_list.md
+++ b/_pages/mailing_list.md
@@ -1,0 +1,38 @@
+---
+layout: toc
+title: Mailing Lists
+permalink: /mailing-lists/
+---
+
+There are two mailing lists for gem5:
+
+* gem5-dev ([subscribe](http://www.gem5.org/mailman/listinfo/gem5-dev)) ---
+Discussions regarding gem5 development. Bug reports should be submitted to our
+[Jira Issue Tracker](https://gem5.atlassian.net), though the gem5-dev mailing
+list can be used to discuss bugs in greater detail.
+* gem5-users ([subscribe](http://www.gem5.org/mailman/listinfo/gem5-users)) ---
+General discussions about gem5 and its use.
+
+# Mail Archive
+
+We maintain archives of our mailing list.
+
+The gem5-dev mail archive can be found [here](
+https://www.mail-archive.com/gem5-dev@gem5.org).
+
+The gem5-users mail archive can be found [here](
+https://www.mail-archive.com/gem5-users@gem5.org).
+
+# Alternative communication channels
+
+[Stack Overflow](https://stackoverflow.com) can be used to crowd-source
+solutions to gem5 related problems. The Stack Overflow `gem5` tag should be
+used: <https://stackoverflow.com/questions/tagged/gem5>). Please make sure
+that your question complies with the [site guidelines](
+https://stackoverflow.com/help/asking) before posting. Interested users can opt
+to receive email notifications for such questions as explained at
+<https://meta.stackexchange.com/questions/25224/email-notifications-for-new-questions-matching-specific-tags>).
+
+Quora is occasionally used : <https://www.quora.com/topic/Gem5-Simulator>.
+While Stack Overflow is preferred, you can use Quora if your question is not on
+topic for Stack Overflow (e.g., a subjective question).

--- a/_pages/mailing_list.md
+++ b/_pages/mailing_list.md
@@ -32,7 +32,3 @@ that your question complies with the [site guidelines](
 https://stackoverflow.com/help/asking) before posting. Interested users can opt
 to receive email notifications for such questions as explained at
 <https://meta.stackexchange.com/questions/25224/email-notifications-for-new-questions-matching-specific-tags>).
-
-Quora is occasionally used : <https://www.quora.com/topic/Gem5-Simulator>.
-While Stack Overflow is preferred, you can use Quora if your question is not on
-topic for Stack Overflow (e.g., a subjective question).

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ title: The gem5 simulator system
         <div class="card-body">
           <h5 class="card-title">Mailing Lists</h5>
           <p class="card-text">gem5 has two main mailing lists where you can ask for help or advice.</p>
-          <a href="http://gem5.org/Mailing_Lists" class="btn btn-primary">Go to Mailing Lists</a>
+          <a href="/mailing-lists/" class="btn btn-primary">Go to Mailing Lists</a>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ title: The gem5 simulator system
         <div class="card-body">
           <h5 class="card-title">Mailing Lists</h5>
           <p class="card-text">gem5 has two main mailing lists where you can ask for help or advice.</p>
-          <a href="/mailing-lists/" class="btn btn-primary">Go to Mailing Lists</a>
+          <a href="/mailing_lists/" class="btn btn-primary">Go to Mailing Lists</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
First of all: This page is likely to change as we migrate our mail services, though this should serve as a decent template to change going forward.

Secondly: Do we want to keep Quora as communication channel?