### PR TITLE
Fixing small typo in `git push` command.

### DIFF
--- a/_pages/documentation/contributing_beginners_guide.md
+++ b/_pages/documentation/contributing_beginners_guide.md
@@ -206,7 +206,7 @@ be fully merged into the gem5 source.
 To start this process, execute:
 
 ```
-git push original HEAD:refs/for/master
+git push origin HEAD:refs/for/master
 ```
 
 At this stage you may receive an error if you're not registered to contribute


### PR DESCRIPTION
`original` -> `origin`