### PR TITLE
fix contributing_beginners_guide path

### DIFF
--- a/_pages/documentation/reporting_problems.md
+++ b/_pages/documentation/reporting_problems.md
@@ -72,7 +72,7 @@ If you have solved a problem that you reported, please let the community know
 about your solution as a follow-up (either in the mailing list or in the Jira
 Issue tracking system). If you have fixed a bug, we'd appreciate if you could
 submit the fix to the gem5 source. Please see our
-[beginners guide to contributing](documentation/contributing_beginners_guide)
+[beginners guide to contributing](/documentation/contributing_beginners_guide)
 on how to do this.
 
 If your issue is with the content of a gem5 document/tutorial being incorrect,


### PR DESCRIPTION
Beginners guide to contribution link in the Reporting Problem page is now directing to /documentation/contributing_beginners_guide instead of /documentation/reporting_problems/documentation/contributing_beginners_guide