### PR TITLE
website: Fix ISCA 2023 poster links

### DIFF
--- a/_pages/events/isca-2023.md
+++ b/_pages/events/isca-2023.md
@@ -128,10 +128,10 @@ Those with posters may hang their poster at the start of the workshop (from 9:00
 
 ### Accepted Posters
 
-* **Analyzing Google Workload Traces in gem5** by Ayaz Akram, Maryam Babaie, and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/analyzing-google-workload-traces-in-gem5.pdf)
+* **Analyzing Google Workload Traces in gem5** by Ayaz Akram, Maryam Babaie, and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/analyzing-google-workload-traces-in-gem5-poster.pdf)
 * **Octopi-cache: An AMD EPYC-like Three-Level Cache Model in gem5** by Hoa Nguyen and Jason Lowe-Power (University of California, Davis)
 * **Improving the Speed of gem5's GPU Regression Tests** by James Braun and Matthew D. Sinclair (University of Wisconsin, Madison)
 * **HammerSim: A tool to model RowHammer** by Kaustav Goswami, Ayaz Akram, Hari Venugopalan, and Jason Lowe-Power (University of California, Davis)
-* **Validating Hardware and SimPoints with gem5: A RISC-V Board Case Study** by Kunal Pai and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/validating-hardware-and-simpoints-with-gem5.pdf)
+* **Validating Hardware and SimPoints with gem5: A RISC-V Board Case Study** by Kunal Pai and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/validating-hardware-and-simpoints-with-gem5-poster.pdf)
 * **QPoints: QEMU to gem5 ARM** by Bhargav Reddy Godala, Ishita Chaturvedi, Yucan Wu (Princeton University), [PDF](/assets/files/workshop-isca-2023/posters/qpoints.pdf)
-* **gem5 Vision** by Parth Shah, Kunal Pai, Harshil Patel, and Arslan Ali (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/gem5-vision.pdf)
+* **gem5 Vision** by Parth Shah, Kunal Pai, Harshil Patel, and Arslan Ali (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/gem5-vision-poster.pdf)

--- a/_pages/events/isca-2023.md
+++ b/_pages/events/isca-2023.md
@@ -132,6 +132,6 @@ Those with posters may hang their poster at the start of the workshop (from 9:00
 * **Octopi-cache: An AMD EPYC-like Three-Level Cache Model in gem5** by Hoa Nguyen and Jason Lowe-Power (University of California, Davis)
 * **Improving the Speed of gem5's GPU Regression Tests** by James Braun and Matthew D. Sinclair (University of Wisconsin, Madison)
 * **HammerSim: A tool to model RowHammer** by Kaustav Goswami, Ayaz Akram, Hari Venugopalan, and Jason Lowe-Power (University of California, Davis)
-* **Validating Hardware and SimPoints with gem5: A RISC-V Board Case Study** by Kunal Pai and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/validating-hardware-and-simpoints-with-gem5-poster.pdf)
+* **Validating Hardware and SimPoints with gem5: A RISC-V Board Case Study** by Kunal Pai, Zhantong Qiu, and Jason Lowe-Power (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/validating-hardware-and-simpoints-with-gem5-poster.pdf)
 * **QPoints: QEMU to gem5 ARM** by Bhargav Reddy Godala, Ishita Chaturvedi, Yucan Wu (Princeton University), [PDF](/assets/files/workshop-isca-2023/posters/qpoints.pdf)
 * **gem5 Vision** by Parth Shah, Kunal Pai, Harshil Patel, and Arslan Ali (University of California, Davis), [PDF](/assets/files/workshop-isca-2023/posters/gem5-vision-poster.pdf)


### PR DESCRIPTION
Made the links point to the correct filename.