### PR TITLE
website: Enable 'www.gem5.org/join-slack' URL

### DIFF
--- a/_pages/join-slack.md
+++ b/_pages/join-slack.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Join Slack
+permalink: /join-slack/
+---
+
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url='https://join.slack.com/t/gem5-workspace/shared_invite/zt-1c8go4yjo-LNb7l~BZ0FagwmVxX08y9g'" />
+  </head>
+  <body>
+    <p>You will be redirected to the gem5 Slack invite soon!</p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: The gem5 simulator system
   <a href="https://github.com/gem5/gem5"><button type="button" class="btn btn-outline-primary">Source</button></a>
   <a href="https://gem5-review.googlesource.com/"><button type="button" class="btn btn-outline-primary">Code Review</button></a>
   <a href="https://arxiv.org/abs/2007.03152"><button type="button" class="btn btn-outline-primary">gem5-20+ paper</button></a>
-  <a href="https://join.slack.com/t/gem5-workspace/shared_invite/zt-1c8go4yjo-LNb7l~BZ0FagwmVxX08y9g"><button type="button" class="btn btn-outline-primary">Join our Slack</button></a>
+  <a href="https://www.gem5.org/join-slack"><button type="button" class="btn btn-outline-primary">Join our Slack</button></a>
   <a href="https://www.youtube.com/channel/UCCpCGEj_835WYmbB0g96lZw"><button type="button" class="btn btn-outline-primary">gem5 Youtube</button></a>
 
   <div class="testing-status">


### PR DESCRIPTION
https://www.gem5.org/join-slack will re-direct to an invitation to join
the slack channel.

This is an easier link to pass around to the gem5 community.