### PR TITLE
website: Update M5Ops Documentation

### DIFF
--- a/_pages/documentation/general_docs/m5ops.md
+++ b/_pages/documentation/general_docs/m5ops.md
@@ -26,7 +26,7 @@ The list of target ISAs is shown below.
 * thumb (arm-linux-gnueabihf-gcc)
 * sparc (sparc64-linux-gnu-gcc)
 * arm64 (aarch64-linux-gnu-gcc)
-* riscv (riscv64-linux-gnu-gcc)
+* riscv (riscv64-unknown-linux-gnu-)
 
 Note if you are using a x86 system for other ISAs you need to have the cross-compiler installed. The name of the cross-compiler is shown inside the parentheses in the list above.
 

--- a/_pages/documentation/general_docs/m5ops.md
+++ b/_pages/documentation/general_docs/m5ops.md
@@ -26,7 +26,7 @@ The list of target ISAs is shown below.
 * thumb (arm-linux-gnueabihf-gcc)
 * sparc (sparc64-linux-gnu-gcc)
 * arm64 (aarch64-linux-gnu-gcc)
-* riscv (riscv64-linux-gnu-gcc)
+* riscv (riscv64-unknown-linux-gnu-gcc)
 
 Note if you are using a x86 system for other ISAs you need to have the cross-compiler installed. The name of the cross-compiler is shown inside the parentheses in the list above.
 

--- a/_pages/documentation/general_docs/m5ops.md
+++ b/_pages/documentation/general_docs/m5ops.md
@@ -30,7 +30,7 @@ The list of target ISAs is shown below.
 
 Note if you are using a x86 system for other ISAs you need to have the cross-compiler installed. The name of the cross-compiler is shown inside the parentheses in the list above.
 
-See util/m5/README.md for more details.
+See [util/m5/README.md](https://github.com/gem5/gem5/blob/stable/util/m5/README.md) for more details.
 
 ## The m5 Utility (FS mode)
 


### PR DESCRIPTION
- Updated the name of the default RISC-V compiler for m5.
- Linked the util/m5 README.md from gem5 in this document

Change-Id: If5de0160ef52b2f1ae83881d9035e86314f149f4