### PR TITLE
website: Add GitHub Workload Status Badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@ title: The gem5 simulator system
     </div>
     <div class="testing-info">
     <ul>
-      <li><a href='https://jenkins.gem5.org/job/nightly/'><img src='https://jenkins.gem5.org/buildStatus/icon?job=nightly&style=plastic&subject=Nightly%20Tests%20ran%20${startTime}%20ago%20for%20${duration}'></a></li>
-      <li><a href='https://jenkins.gem5.org/job/weekly/'><img src='https://jenkins.gem5.org/buildStatus/icon?job=weekly&style=plastic&subject=Weekly%20Tests%20ran%20${startTime}%20ago%20for%20${duration}'></a></li>
-      <li><a href='https://jenkins.gem5.org/job/compiler-checks/'><img src='https://jenkins.gem5.org/buildStatus/icon?job=compiler-checks&style=plastic&subject=Compiler%20Tests%20ran%20${startTime}%20ago%20for%20${duration}'></a></li>
+      <li><a href='https://github.com/gem5/gem5/actions/workflows/daily-tests.yaml'><img src='https://github.com/gem5/gem5/actions/workflows/daily-tests.yaml/badge.svg'></a></li>
+      <li><a href='https://github.com/gem5/gem5/actions/workflows/weekly-tests.yaml'><img src='https://github.com/gem5/gem5/actions/workflows/weekly-tests.yaml/badge.svg'></a></li>
+      <li><a href='https://github.com/gem5/gem5/actions/workflows/compiler-tests.yaml'><img src='https://github.com/gem5/gem5/actions/workflows/compiler-tests.yaml/badge.svg'></a></li>
     </ul>
     </div>
   </div>


### PR DESCRIPTION
These replace our old Jenkins status badges.

Adds status badges for:

* Daily Tests
* Weekly Tests
* Compiler Tests