### PR TITLE
Rename `HelloObject` to `SimpleObject`

### DIFF
--- a/_pages/documentation/learning_gem5/part2/part2_1_helloobject.md
+++ b/_pages/documentation/learning_gem5/part2/part2_1_helloobject.md
@@ -11,8 +11,11 @@ author: Jason Lowe-Power
 Creating a *very* simple SimObject
 ==================================
 
-**Note**: gem5 has SimObject named `SimpleObject`. Implementing another
-`SimpleObject` SimObject will result in confusing compiler issues.
+**Note**: You can find the files mentioned in this tutorial completed under
+`src/learning_gem5/part2` and `configs/learning_gem5/part2`. To follow this
+tutorial, you can delete these or move them elsewhere or name your additions
+differently (e.g. `MySimpleObject` instead of `SimpleObject`); Implementing
+another `SimpleObject` SimObject will result in confusing compiler issues.
 
 Almost all objects in gem5 inherit from the base SimObject type.
 SimObjects export the main interfaces to all objects in gem5. SimObjects
@@ -25,7 +28,7 @@ floating point numbers, they can also have other SimObjects as
 parameters. This allows you to create complex system hierarchies, like
 real machines.
 
-In this chapter, we will walk through creating a simple "HelloWorld"
+In this chapter, we will walk through creating a simple "SimpleObject"
 SimObject. The goal is to introduce you to how SimObjects are created
 and the required boilerplate code for all SimObjects. We will also
 create a simple `Python` configuration script which instantiates our
@@ -58,11 +61,9 @@ SimObject, we are just going to start out with no parameters. Thus, we
 simply need to declare a new class for our SimObject and set it's name
 and the C++ header that will define the C++ class for the SimObject.
 
-We can create a file, `HelloObject.py`, in `src/learning_gem5/part2`.
-If you have cloned the gem5 repository you'll have the files mentioned
-in this tutorial completed under `src/learning_gem5/part2` and
-`configs/learning_gem5/part2`. You can delete these or move them
-elsewhere to follow this tutorial.
+We can create a file,
+[`SimpleObject.py`](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/SimpleObject.py)
+in `src/learning_gem5/part2`.
 
 ```python
 from m5.params import *
@@ -75,7 +76,7 @@ class HelloObject(SimObject):
 ```
 
 [//]: # You can find the complete file
-[//]: # [here](/_static/scripts/part2/helloobject/HelloObject.py)
+[//]: # [here](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/SimpleObject.py)
 
 It is not required that the `type` be the same as the name of the class,
 but it is convention. The `type` is the C++ class that you are wrapping
@@ -94,8 +95,8 @@ base are declared within the gem5 namespace!
 Step 2: Implement your SimObject in C++
 ---------------------------------------
 
-Next, we need to create `hello_object.hh` and `hello_object.cc` in
-`src/learning_gem5/part2/` directory which will implement the `HelloObject`.
+Next, we need to create `simple_object.hh` and `simple_object.cc` in
+`src/learning_gem5/part2` directory which will implement the `SimpleObject`.
 
 We'll start with the header file for our `C++` object. By convention,
 gem5 wraps all header files in `#ifndef/#endif` with the name of the
@@ -105,7 +106,7 @@ SimObjects should be declared within the gem5 namespace. Therefore,
 we declare our class within the `namespace gem5` scope.
 
 The only thing we need to do in the file is to declare our class. Since
-`HelloObject` is a SimObject, it must inherit from the C++ SimObject
+`SimpleObject` is a SimObject, it must inherit from the C++ SimObject
 class. Most of the time, your SimObject's parent will be a subclass of
 SimObject, not SimObject itself.
 
@@ -117,37 +118,37 @@ The constructor for all SimObjects assumes it will take a parameter
 object. This parameter object is automatically created by the build
 system and is based on the `Python` class for the SimObject, like the
 one we created above. The name for this parameter type is generated
-automatically from the name of your object. For our "HelloObject" the
-parameter type's name is "HelloObjectParams".
+automatically from the name of your object. For our "SimpleObject" the
+parameter type's name is "SimpleObjectParams".
 
 The code required for our simple header file is listed below.
 
 ```cpp
-#ifndef __LEARNING_GEM5_HELLO_OBJECT_HH__
-#define __LEARNING_GEM5_HELLO_OBJECT_HH__
+#ifndef __LEARNING_GEM5_SIMPLE_OBJECT_HH__
+#define __LEARNING_GEM5_SIMPLE_OBJECT_HH__
 
-#include "params/HelloObject.hh"
+#include "params/SimpleObject.hh"
 #include "sim/sim_object.hh"
 
 namespace gem5
 {
 
-class HelloObject : public SimObject
+class SimpleObject : public SimObject
 {
   public:
-    HelloObject(const HelloObjectParams &p);
+    SimpleObject(const SimpleObjectParams &p);
 };
 
 } // namespace gem5
 
-#endif // __LEARNING_GEM5_HELLO_OBJECT_HH__
+#endif // __LEARNING_GEM5_SIMPLE_OBJECT_HH__
 ```
 
 [//]: # You can find the complete file
-[//]: # [here](/_pages/static/scripts/part2/helloobject/hello_object.hh).
+[//]: # [here](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/simple_object.hh).
 
 Next, we need to implement *two* functions in the `.cc` file, not just
-one. The first function, is the constructor for the `HelloObject`. Here
+one. The first function, is the constructor for the `SimpleObject`. Here
 we simply pass the parameter object to the SimObject parent and print
 "Hello world!"
 
@@ -157,14 +158,14 @@ will modify this to use debug flags instead. However, for now, we'll
 simply use `std::cout` because it is simple.
 
 ```cpp
-#include "learning_gem5/part2/hello_object.hh"
+#include "learning_gem5/part2/simple_object.hh"
 
 #include <iostream>
 
 namespace gem5
 {
 
-HelloObject::HelloObject(const HelloObjectParams &params) :
+SimpleObject::SimpleObject(const SimpleObjectParams &params) :
     SimObject(params)
 {
     std::cout << "Hello World! From a SimObject!" << std::endl;
@@ -172,6 +173,9 @@ HelloObject::HelloObject(const HelloObjectParams &params) :
 
 } // namespace gem5
 ```
+
+[//]: # You can find the complete file
+[//]: # [here](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/simple_object.cc).
 
 **Note**: If the constructor of your SimObject follows the following
 signature,
@@ -186,11 +190,6 @@ instance of the SimObject. Most SimObject will follow this pattern; however,
 if your SimObject does not follow this pattern,
 [the gem5 SimObject documetation](http://doxygen.gem5.org/release/current/classSimObject.html#details)
 provides more information about manually implementing the `create()` method.
-
-
-[//]: # You can find the complete file
-[//]: # [here](/_pages/static/scripts/part2/helloobject/hello_object.cc).
-
 
 Step 3: Register the SimObject and C++ file
 -------------------------------------------
@@ -219,12 +218,12 @@ is the required code.
 ```python
 Import('*')
 
-SimObject('HelloObject.py', sim_objects=['HelloObject'])
-Source('hello_object.cc')
+SimObject('SimpleObject.py', sim_objects=['SimpleObject'])
+Source('simple_object.cc')
 ```
 
 [//]: # You can find the complete file
-[//]: # [here](/_pages/static/scripts/part2/helloobject/SConscript).
+[//]: # [here](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/SConscript).
 
 Step 4: (Re)-build gem5
 -----------------------
@@ -241,7 +240,7 @@ Step 5: Create the config scripts to use your new SimObject
 -----------------------------------------------------------
 
 Now that you have implemented a SimObject, and it has been compiled into
-gem5, you need to create or modify a `Python` config file `run_hello.py` in
+gem5, you need to create or modify a `Python` config file `run_simple.py` in
 `configs/learning_gem5/part2` to instantiate your object. Since your object
 is very simple a system object is not required! CPUs are not needed, or
 caches, or anything, except a `Root` object. All gem5 instances require a
@@ -262,7 +261,7 @@ instances.
 root = Root(full_system = False)
 ```
 
-Now, you can instantiate the `HelloObject` you created. All you need to
+Now, you can instantiate the `SimpleObject` you created. All you need to
 do is call the `Python` "constructor". Later, we will look at how to
 specify parameters via the `Python` constructor. In addition to creating
 an instantiation of your object, you need to make sure that it is a
@@ -270,7 +269,7 @@ child of the root object. Only SimObjects that are children of the
 `Root` object are instantiated in `C++`.
 
 ```python
-root.hello = HelloObject()
+root.hello = SimpleObject()
 ```
 
 Finally, you need to call `instantiate` on the `m5` module and actually
@@ -286,25 +285,21 @@ print('Exiting @ tick {} because {}'
 ```
 
 [//]: # You can find the complete file
-[//]: # [here](/_pages/static/scripts/part2/helloobject/run_hello.py).
+[//]: # [here](https://github.com/gem5/gem5/blob/stable/configs/learning_gem5/part2/run_simple.py).
 
 Remember to rebuild gem5 after modifying files in the src/ directory. The
 command line to run the config file is in the output below after
 'command line:'. The output should look something like the following:
 
-Note: If the code for the future section "Adding parameters to SimObjects
-and more events", (goodbye_object) is in your `src/learning_gem5/part2`
-directory, run_hello.py will cause an error. If you delete those files or
-move them outside of the gem5 directory `run_hello.py` should give the output
-below.
+Executing `run_hello.py` should give the output below.
 ```
     gem5 Simulator System.  http://gem5.org
     gem5 is copyrighted software; use the --copyright option for details.
 
-    gem5 compiled May  4 2016 11:37:41
-    gem5 started May  4 2016 11:44:28
+    gem5 compiled Sep 12 2023 11:37:41
+    gem5 started Sep 12 2023 11:44:28
     gem5 executing on mustardseed.cs.wisc.edu, pid 22480
-    command line: build/X86/gem5.opt configs/learning_gem5/part2/run_hello.py
+    command line: build/X86/gem5.opt configs/learning_gem5/part2/run_simple.py
 
     Global frequency set at 1000000000000 ticks per second
     Hello World! From a SimObject!
@@ -312,6 +307,7 @@ below.
     info: Entering event queue @ 0.  Starting simulation...
     Exiting @ tick 18446744073709551615 because simulate() limit reached
 ```
+
 Congrats! You have written your first SimObject. In the next chapters,
 we will extend this SimObject and explore what you can do with
 SimObjects.

--- a/_pages/documentation/learning_gem5/part2/part2_2_debugging.md
+++ b/_pages/documentation/learning_gem5/part2/part2_2_debugging.md
@@ -199,7 +199,7 @@ to replace this and use gem5's debugging facilities instead.
 
 When creating a new debug flag, we first have to declare it in a
 SConscript file. Add the following to the SConscript file in the
-directory with your hello object code (`src/learning_gem5/SConscript`).
+directory with your `SimpleObject` code (`src/learning_gem5/part2/SConscript`).
 
 ```python
 DebugFlag('HelloExample')
@@ -215,7 +215,7 @@ capitalization) as what we declare in the SConscript file. Therefore, we
 need to include the automatically generated header file in any files
 where we plan to use the debug flag.
 
-In the `hello_object.cc` file, we need to include the header file.
+In the `simple_object.cc` file, we need to include the header file.
 
 ```cpp
 #include "base/trace.hh"
@@ -231,7 +231,7 @@ DPRINTF(HelloExample, "Created the hello object\n");
 
 `DPRINTF` is a C++ macro. The first parameter is a *debug flag* that has
 been declared in a SConscript file. We can use the flag `HelloExample` since we
-declared it in the `src/learning_gem5/SConscript` file. The rest of the
+declared it in the `src/learning_gem5/part2/SConscript` file. The rest of the
 arguments are variable and can be anything you would pass to a `printf`
 statement.
 
@@ -240,16 +240,16 @@ get the following result.
 
 ```
 scons build/X86/gem5.opt
-build/X86/gem5.opt --debug-flags=HelloExample configs/learning_gem5/part2/run_hello.py
+build/X86/gem5.opt --debug-flags=HelloExample configs/learning_gem5/part2/run_simple.py
 ```
 
     gem5 Simulator System.  http://gem5.org
     gem5 is copyrighted software; use the --copyright option for details.
 
-    gem5 compiled Jan  4 2017 09:40:10
-    gem5 started Jan  4 2017 09:41:01
+    gem5 compiled Sep 13 2023 09:40:10
+    gem5 started Sep 13 2023 09:41:01
     gem5 executing on chinook, pid 29078
-    command line: build/X86/gem5.opt --debug-flags=HelloExample configs/learning_gem5/part2/run_hello.py
+    command line: build/X86/gem5.opt --debug-flags=HelloExample configs/learning_gem5/part2/run_simple.py
 
     Global frequency set at 1000000000000 ticks per second
           0: hello: Created the hello object
@@ -258,9 +258,7 @@ build/X86/gem5.opt --debug-flags=HelloExample configs/learning_gem5/part2/run_he
     Exiting @ tick 18446744073709551615 because simulate() limit reached
 
 You can find the updated SConcript file
-[here](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable/src/learning_gem5/part2/SConscript)
-and the updated hello object code
-[here](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable/src/learning_gem5/part2/hello_object.cc).
+[here](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable/src/learning_gem5/part2/SConscript).
 
 Debug output
 ------------

--- a/_pages/documentation/learning_gem5/part2/part2_3_events.md
+++ b/_pages/documentation/learning_gem5/part2/part2_3_events.md
@@ -12,8 +12,8 @@ Event-driven programming
 ========================
 
 gem5 is an event-driven simulator. In this chapter, we will explore how
-to create and schedule events. We will be building from the simple
-`HelloObject` from [hello-simobject-chapter](../helloobject).
+to create and schedule events. We will be building `HelloObject` from the
+simple `SimpleObject` described in [simple-simobject-chapter](../helloobject).
 
 Creating a simple event callback
 --------------------------------
@@ -57,7 +57,7 @@ event. When printing the name, there will be an automatic
 The first parameter is simply a function that takes no parameters and
 has no return value (`std::function<void(void)>`). Usually, this is a
 simple lambda function that calls a member function. However, it can be
-any function you want. Below, we captute `this` in the lambda (`[this]`)
+any function you want. Below, we capture `this` in the lambda (`[this]`)
 so we can call member functions of the instance of the class.
 
 ```cpp
@@ -102,7 +102,7 @@ HelloObject::startup()
 ```
 
 Here, we simply schedule the event to execute at tick 100. Normally, you
-would use some offset from `curTick()`, but since we know the startup()
+would use some offset from `curTick()`, but since we know the `startup()`
 function is called when the time is currently 0, we can use an explicit
 tick value.
 


### PR DESCRIPTION
These changes adjust the page to use the `SimpleObject` nomenclature in favor of `HelloObject`.
In gem5/src/learning_gem5/part2, the [`HelloObject.py`](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/HelloObject.py) is more sophisticated than what this tutorial shows; it seems to be called [`SimpleObject.py`](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/SimpleObject.py) in the upstream now.

To minimize the changes of this PR, for now ....
- I did not update `_/static/scripts/part2/helloobject`, but instead linked to the gem5 repo.
- I did not change the name of this page (e.g. from `part2_1_helloobject.md` to `part2_1_simpleobject.md`)
- I did not change the - to my understanding inconsistent - use of `"` and `` ` `` for emphasis
- I did not introduce a new file similar to [`simple_object.cc`](https://github.com/gem5/gem5/blob/stable/src/learning_gem5/part2/simple_object.cc), but using `DPRINTF` instead.

I'd gladly add these changes if they are desired - just let me know.