### PR TITLE
website: Update website to support Ubuntu 24.04

### DIFF
--- a/_pages/documentation/general_docs/building/index.md
+++ b/_pages/documentation/general_docs/building/index.md
@@ -51,6 +51,18 @@ generation and playback.
 libraries. It is a necessary dependency if you wish to use the SystemC
 implementation.
 
+### Setup on Ubuntu 24.04 (gem5 > v24.0)
+
+If compiling gem5 on Ubuntu 24.04, or related Linux distributions, you may
+install all these dependencies using APT:
+
+```
+sudo apt install build-essential scons python3-dev git pre-commit zlib1g zlib1g-dev \
+    libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev libboost-all-dev  \
+    libhdf5-serial-dev python3-pydot python3-venv python3-tk mypy m4 libcapstone-dev \
+    libpng-dev libelf-dev pkg-config wget cmake doxygen
+```
+
 ### Setup on Ubuntu 22.04 (gem5 >= v21.1)
 
 If compiling gem5 on Ubuntu 22.04, or related Linux distributions, you may
@@ -78,15 +90,20 @@ sudo apt install build-essential git m4 scons zlib1g zlib1g-dev \
 For users struggling to setup an environment to build and run gem5, we provide
 the following Docker Images:
 
+Ubuntu 24.04 with all optional dependencies:
+[ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0](
+https://ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0) ([source Dockerfile](
+https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile)).
+
+Ubuntu 24.04 with minimum dependencies:
+[ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0](
+https://ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0) ([source Dockerfile](
+https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile)).
+
 Ubuntu 22.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-22.04_all-dependencies:v22-1](
 https://ghcr.io/gem5/ubuntu-22.04_all-dependencies:v22-1) ([source Dockerfile](
 https://github.com/gem5/gem5/blob/v22.1.0.0/util/dockerfiles/ubuntu-22.04_all-dependencies/Dockerfile)).
-
-Ubuntu 22.04 with minimum dependencies:
-[ghcr.io/gem5/ubuntu-22.04_min-dependencies:v22-1](
-https://ghcr.io/gem5/ubuntu-22.04_min-dependencies:v22-1) ([source Dockerfile](
-https://github.com/gem5/gem5/blob/v22.1.0.0/util/dockerfiles/ubuntu-22.04_min-dependencies/Dockerfile)).
 
 Ubuntu 20.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-20.04_all-dependencies:v22-1](

--- a/_pages/documentation/general_docs/building/index.md
+++ b/_pages/documentation/general_docs/building/index.md
@@ -12,21 +12,14 @@ authors: Bobby R. Bruce
 ## Supported operating systems and environments
 
 gem5 has been designed with a Linux environment in mind. We test regularly
-on **Ubuntu 20.04**, and **Ubuntu 22.04** to ensure gem5 functions well in
+on **Ubuntu 20.04**, **Ubuntu 22.04** and **Ubuntu 24.04** to ensure gem5 functions well in
 these environments. Though **any Linux based OS should function if the correct
 dependencies are installed**. We ensure that gem5 is compilable with both gcc
 and clang (see [Dependencies](#dependencies)  below for compiler version
 information).
 
-**Mac OS should work when compiling using the clang compiler**, with all other
-dependencies installed. However, at present, we do not officially test our
-builds on Mac OS. **We therefore cannot guarantee the same stability for those
-wishing to compile and run gem5 in Mac OS as we can in Linux-based systems**.
-[In later versions of gem5, we hope to more effectively support Mac OS through
-improved testing](https://gem5.atlassian.net/browse/GEM5-538).
-
 As of gem5 21.0, **we support building and running gem5 with Python 3.6+
-only.**. gem5 20.0 was our last version of gem5 to provide support for Python
+only**. gem5 20.0 was our last version of gem5 to provide support for Python
 2.
 
 If running gem5 in a suitable OS/environment is not possible, we have provided
@@ -92,13 +85,15 @@ the following Docker Images:
 
 Ubuntu 24.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0](
-https://ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0) ([source Dockerfile](
-https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile)).
+https://ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0)
+<!-- add this when files are merged to stable
+ ([source Dockerfile](https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_all-dependencies/Dockerfile)). -->
 
 Ubuntu 24.04 with minimum dependencies:
 [ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0](
-https://ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0) ([source Dockerfile](
-https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile)).
+https://ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0)
+<!-- add this line when files are merged to stable
+([source Dockerfile](https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile)). -->
 
 Ubuntu 22.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-22.04_all-dependencies:v22-1](


### PR DESCRIPTION
This PR introduces support for Ubuntu 24.04. The links to the Dockerfiles for Ubuntu 24.04 are currently commented out, pending the merge of the files into the stable branch.