### PR TITLE
website: Final update to the bootcamp 2024 page

### DIFF
--- a/_pages/community/events/bootcamp-2024.md
+++ b/_pages/community/events/bootcamp-2024.md
@@ -15,7 +15,7 @@ tabs:
         Thank you to everyone who contributed to this bootcamp and helped make it a success.
 
         - [YouTube Videos](https://www.youtube.com/playlist?list=PL_hVbFs_loVR_8ntTTmmG6YEq3Po_4snu)
-        - [Slides](https://bootcamp.gem5.org/)
+        - [Slides](gem5bootcamp.github.io/2024)
 
         ---
 

--- a/_pages/community/events/bootcamp-2024.md
+++ b/_pages/community/events/bootcamp-2024.md
@@ -8,6 +8,17 @@ tabs:
     id: about
     active: true
     content: |
+        ---
+
+        **After the event:**
+
+        Thank you to everyone who contributed to this bootcamp and helped make it a success.
+
+        - [YouTube Videos](https://www.youtube.com/playlist?list=PL_hVbFs_loVR_8ntTTmmG6YEq3Po_4snu)
+        - [Slides](https://bootcamp.gem5.org/)
+
+        ---
+
         We are happy to announce the **gem5 bootcamp 2024!**
 
         **WHEN: July 29th - August 2nd 2024**

--- a/index.html
+++ b/index.html
@@ -74,9 +74,8 @@ title: The gem5 simulator system
           <p>
             Explore our blog for the latest updates and news about gem5, offering a valuable resource to stay informed on the project's developments.
           </p>
-          <a href="/events/bootcamp-2024"><button class="btn-main-link"> We are happy to announce the <b>gem5 bootcamp 2024!</b></button></a>
           <a href="{{ site.posts.first.url }}"><button class="btn-main-link">{{ site.posts.first.title }}</button></a>
-          <!-- <a href="{{ site.posts[1].url }}"><button class="btn-main-link">{{ site.posts[1].title }}</button></a> -->
+          <a href="{{ site.posts[1].url }}"><button class="btn-main-link">{{ site.posts[1].title }}</button></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR updates the bootcamp 2024 page with slides and videos from the event and removes the bootcamp link from the homepage.