### PR TITLE
website: Update code-block style

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -30,6 +30,7 @@ a, a:hover {
 
 a {
   text-decoration: none;
+  font-weight: bold;
 }
 
 a:hover {
@@ -38,14 +39,19 @@ a:hover {
 
 /**** CODE BLOCK ****/
 pre code {
-	color: white !important;
-	background-color: black;
+  color: black;
+	background-color: #f0f0f0;
   // border: 2px solid grey;
   display: block;
   padding: 20px;
 	overflow-x: scroll;
 }
 
+p code {
+  color: black;
+  background-color: #f0f0f0;
+  padding: 3px 6px;
+}
 
 /**** NAVBAR ****/
 .navbar {


### PR DESCRIPTION
This PR updates the styling of code block elements on the website. Below are two screenshots illustrating the changes made.

Before:
![before](https://github.com/user-attachments/assets/84e213ef-b164-4c9b-8728-c0b3409a0460)

After:
![after](https://github.com/user-attachments/assets/749af272-7e5a-4e08-8015-5a431ecacc82)
