### PR TITLE
website: Add Sphinx documentation to website using GitHub Actions

### DIFF
--- a/.github/workflows/sphinx-to-website.yaml
+++ b/.github/workflows/sphinx-to-website.yaml
@@ -1,0 +1,71 @@
+---
+  name: Generate Sphinx Docs and Commit to Website
+  on:
+    schedule:
+      - cron: 0 13 * * 1 # run it once a week
+  jobs:
+      build-sphinx:
+          permissions:
+              contents: write
+  
+          runs-on: ubuntu-latest
+          container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+          steps:
+              - name: checkout gem5
+                uses: actions/checkout@v4
+                with:
+                    repository: gem5/gem5
+                    path: gem5
+                    ref: stable
+
+              - name: checkout website
+                uses: actions/checkout@v4
+                with:
+                    path: website
+                    ref: stable
+              - name: install Sphinx
+                run: |
+                    apt-get update
+                    apt-get install python3-sphinx -y --fix-missing
+                    sphinx-build --version
+  
+              - name: Cache gem5 # remove caching in final (?)
+                id: cache-gem5
+                uses: actions/cache@v4
+                with:
+                    path: gem5/build/ALL
+                    key: gem5.opt
+              - name: Build gem5
+                # if: steps.cache-gem5.outputs.cache-hit != 'true'
+                # The entire build/ALL folder is cached, so try commenting this
+                # out to see if gem5 will build relatively quickly
+                run: |
+                  cd gem5
+                  scons build/ALL/gem5.opt -j $(nproc)
+              - name: Generate RST
+                run: |
+                    cd gem5/docs
+                    ../build/ALL/gem5.opt gem5-sphinx-apidoc -o . ../src/python/gem5 -F -e
+  
+              - name: Generate Sphinx docs
+                run: |
+                    cd gem5/docs
+                    ../build/ALL/gem5.opt gem5-sphinx -M html . _build
+              - name: Add frontmatter
+                run: |
+                    rm -r website/_pages/documentation/general_docs/sphinx_docs
+                    mkdir website/_pages/documentation/general_docs/sphinx_docs
+                    cp -r gem5/docs/_build/html/* website/_pages/documentation/general_docs/sphinx_docs
+                    cd website
+                    python3 add-sphinx-docs.py
+              - name: Commit documentation changes to gem5/website repo
+                continue-on-error: true
+                run: |
+                    # Note: the following account information will not work on GHES
+                    cd website
+                    git branch
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                    git add .
+                    git commit -m "Update Sphinx documentation" -a || true
+                    git push

--- a/.github/workflows/sphinx-to-website.yaml
+++ b/.github/workflows/sphinx-to-website.yaml
@@ -59,13 +59,10 @@
                     cd website
                     python3 add-sphinx-docs.py
               - name: Commit documentation changes to gem5/website repo
-                continue-on-error: true
-                run: |
-                    # Note: the following account information will not work on GHES
-                    cd website
-                    git branch
-                    git config user.name "github-actions[bot]"
-                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                    git add .
-                    git commit -m "Update Sphinx documentation" -a || true
-                    git push
+                uses: EndBug/add-and-commit@v9
+                with:
+                    add: '.'
+                    author_name: Github Action
+                    author_email: action@github.com
+                    message: "Update Sphinx documentation"
+                    cwd: './website'

--- a/.github/workflows/sphinx-to-website.yaml
+++ b/.github/workflows/sphinx-to-website.yaml
@@ -28,17 +28,7 @@
                     apt-get update
                     apt-get install python3-sphinx -y --fix-missing
                     sphinx-build --version
-  
-              - name: Cache gem5 # remove caching in final (?)
-                id: cache-gem5
-                uses: actions/cache@v4
-                with:
-                    path: gem5/build/ALL
-                    key: gem5.opt
               - name: Build gem5
-                # if: steps.cache-gem5.outputs.cache-hit != 'true'
-                # The entire build/ALL folder is cached, so try commenting this
-                # out to see if gem5 will build relatively quickly
                 run: |
                   cd gem5
                   scons build/ALL/gem5.opt -j $(nproc)
@@ -61,7 +51,7 @@
               - name: Commit documentation changes to gem5/website repo
                 uses: EndBug/add-and-commit@v9
                 with:
-                    add: '.'
+                    add: './_pages/documentation/general_docs/sphinx_docs'
                     author_name: Github Action
                     author_email: action@github.com
                     message: "Update Sphinx documentation"

--- a/_data/documentation.yml
+++ b/_data/documentation.yml
@@ -26,6 +26,10 @@ docs:
     - title: Using KVM
       id: using_kvm
       url: /documentation/general_docs/using_kvm
+      
+    - title: Sphinx Documentation
+      id: sphinx-docs
+      url: /documentation/general_docs/stdlib_api/
 
     - title: Doxygen
       id: doxygen-docs

--- a/add-sphinx-docs.py
+++ b/add-sphinx-docs.py
@@ -1,7 +1,34 @@
+# Copyright (c) 2024 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import os
 
 search_bar_lines = []
 html = []
+
 
 def remove_searchbar(html):
     search_flag = False
@@ -10,12 +37,18 @@ def remove_searchbar(html):
             search_flag = True
         if search_flag == True:
             html[index] = ""
-        if '<script>document.getElementById(\'searchbox\').style.display = "block"</script>' in line:
+        if (
+            "<script>document.getElementById('searchbox').style.display = \"block\"</script>"
+            in line
+        ):
             search_flag = False
     return html
 
 
-with open(f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html", "r+") as f:
+with open(
+    f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html",
+    "r+",
+) as f:
     html = f.readlines()
     f.seek(0, 0)
     f.truncate(0)
@@ -23,8 +56,9 @@ with open(f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html"
     f.write("---\n")
     f.write(f'title: "Sphinx Documentation"\n')
     f.write("parent: sphinx-docs\n")
-    f.write(f"permalink: /documentation/general_docs/stdlib_api/\n")
+    f.write(f"permalink: documentation/general_docs/stdlib_api\n")
     f.write("---\n")
+
     for index, line in enumerate(html):
         modified_line = None
 
@@ -62,14 +96,16 @@ with open(f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html"
         html[index] = modified_line
 
     html = remove_searchbar(html)
-    
+
     for line in html:
         f.write(line)
 
 
 for filename in os.listdir("./_pages/documentation/general_docs/sphinx_docs"):
     if filename.startswith("gem5"):
-        with open(f"./_pages/documentation/general_docs/sphinx_docs/{filename}", "r+") as f:
+        with open(
+            f"./_pages/documentation/general_docs/sphinx_docs/{filename}", "r+"
+        ) as f:
             html = f.readlines()
             f.seek(0, 0)
             f.truncate(0)
@@ -77,10 +113,10 @@ for filename in os.listdir("./_pages/documentation/general_docs/sphinx_docs"):
             f.write(f'title: "{filename}"\n')
             f.write("parent: sphinx-docs\n")
             f.write(
-                f"permalink: /documentation/general_docs/stdlib_api/{filename}\n"
+                f"permalink: /documentation/general_docs/sphinx_docs/{filename}\n"
             )
             f.write("---\n")
             html = remove_searchbar(html)
-            
+
             for line in html:
                 f.write(line)

--- a/add-sphinx-docs.py
+++ b/add-sphinx-docs.py
@@ -23,9 +23,8 @@ with open(f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html"
     f.write("---\n")
     f.write(f'title: "Sphinx Documentation"\n')
     f.write("parent: sphinx-docs\n")
-    f.write(f"permalink: /documentation/general_docs/sphinx_docs/index.html\n")
+    f.write(f"permalink: /documentation/general_docs/stdlib_api/\n")
     f.write("---\n")
-
     for index, line in enumerate(html):
         modified_line = None
 
@@ -78,7 +77,7 @@ for filename in os.listdir("./_pages/documentation/general_docs/sphinx_docs"):
             f.write(f'title: "{filename}"\n')
             f.write("parent: sphinx-docs\n")
             f.write(
-                f"permalink: /documentation/general_docs/sphinx_docs/{filename}\n"
+                f"permalink: /documentation/general_docs/stdlib_api/{filename}\n"
             )
             f.write("---\n")
             html = remove_searchbar(html)

--- a/add-sphinx-docs.py
+++ b/add-sphinx-docs.py
@@ -1,0 +1,87 @@
+import os
+
+search_bar_lines = []
+html = []
+
+def remove_searchbar(html):
+    search_flag = False
+    for index, line in enumerate(html):
+        if '<div id="searchbox" style="display: none" role="search">' in line:
+            search_flag = True
+        if search_flag == True:
+            html[index] = ""
+        if '<script>document.getElementById(\'searchbox\').style.display = "block"</script>' in line:
+            search_flag = False
+    return html
+
+
+with open(f"./_pages/documentation/general_docs/sphinx_docs/_modules/index.html", "r+") as f:
+    html = f.readlines()
+    f.seek(0, 0)
+    f.truncate(0)
+    # Add frontmatter so the docs pages can be accessed in the website
+    f.write("---\n")
+    f.write(f'title: "Sphinx Documentation"\n')
+    f.write("parent: sphinx-docs\n")
+    f.write(f"permalink: /documentation/general_docs/sphinx_docs/index.html\n")
+    f.write("---\n")
+
+    for index, line in enumerate(html):
+        modified_line = None
+
+        # make the links at the bottom of index.html work
+        if "<li><a href=" in line:
+            if (
+                '<li><a href="../index.html">Documentation overview</a><ul>'
+                in line
+            ):
+                modified_line = (
+                    '<li><a href="./index.html">Documentation overview</a><ul>'
+                )
+            else:
+                # For links to the other documentation pages from index.html, replace the `.` in the path with `/`. This makes things more consistent and allows links from index.html to a Sphinx page and links between two Sphinx pages to work.
+                modified_line = (
+                    line.replace("/", ".")
+                    .replace("<.a>", "</a>")
+                    .replace("<.li>", "</li>")
+                )
+        elif (
+            '<li class="toctree-l1"><a class="reference internal" href="../gem5.html">gem5 package</a></li>'
+            in line
+        ):
+            print("../gem5.html switched to ./gem5.html")
+            modified_line = '<li class="toctree-l1"><a class="reference internal" href="./gem5.html">gem5 package</a></li>'
+
+        elif '<h1 class="logo"><a href="../index.html">gem5</a></h1>' in line:
+            print("../index.html switched to ./index.html")
+            modified_line = (
+                '<h1 class="logo"><a href="./index.html">gem5</a></h1>'
+            )
+        else:
+            modified_line = line
+
+        html[index] = modified_line
+
+    html = remove_searchbar(html)
+    
+    for line in html:
+        f.write(line)
+
+
+for filename in os.listdir("./_pages/documentation/general_docs/sphinx_docs"):
+    if filename.startswith("gem5"):
+        with open(f"./_pages/documentation/general_docs/sphinx_docs/{filename}", "r+") as f:
+            html = f.readlines()
+            f.seek(0, 0)
+            f.truncate(0)
+            f.write("---\n")
+            f.write(f'title: "{filename}"\n')
+            f.write("parent: sphinx-docs\n")
+            f.write(
+                f"permalink: /documentation/general_docs/sphinx_docs/{filename}\n"
+            )
+            f.write("---\n")
+            html = remove_searchbar(html)
+            
+            for line in html:
+                f.write(line)


### PR DESCRIPTION
This PR adds a workflow file that builds the Sphinx documentation and pushes it to the gem5 website. Currently, it is set to run once a week and build documentation for the stable version of gem5. This PR also includes a Python script that adds frontmatter and makes other alterations to the HTML files generated by Sphinx so they are compatible with the gem5 website.

This was tested using my own forks of the gem5 website and the gem5 repo, so some issues may come up when this workflow is run with the gem5/website repo.

The workflow file also won't work right now, as the current stable version of gem5 doesn't have the `docs` folder needed to build Sphinx. This won't be a problem once v 24.1 comes out, however.