### PR TITLE
Add workflow_dispatch to sphinx-to-website.yaml

### DIFF
--- a/.github/workflows/sphinx-to-website.yaml
+++ b/.github/workflows/sphinx-to-website.yaml
@@ -1,6 +1,7 @@
 ---
 name: Generate Sphinx Docs and Commit to Website
 on:
+    workflow_dispatch:
     schedule:
         - cron: 0 22 * * 2 # run it once a week
 jobs:


### PR DESCRIPTION
This change allows the Sphinx workflow to be run manually in addition to on a schedule.