### PR TITLE
website: add slash to end of permalink for Sphinx index.html

### DIFF
--- a/_pages/documentation/general_docs/sphinx_docs/_modules/index.html
+++ b/_pages/documentation/general_docs/sphinx_docs/_modules/index.html
@@ -1,7 +1,7 @@
 ---
 title: "Sphinx Documentation"
 parent: sphinx-docs
-permalink: documentation/general_docs/stdlib_api
+permalink: documentation/general_docs/stdlib_api/
 ---
 <!DOCTYPE html>
 

--- a/add-sphinx-docs.py
+++ b/add-sphinx-docs.py
@@ -56,7 +56,7 @@ with open(
     f.write("---\n")
     f.write(f'title: "Sphinx Documentation"\n')
     f.write("parent: sphinx-docs\n")
-    f.write(f"permalink: documentation/general_docs/stdlib_api\n")
+    f.write(f"permalink: documentation/general_docs/stdlib_api/\n")
     f.write("---\n")
 
     for index, line in enumerate(html):


### PR DESCRIPTION
This commit attempts to fix an issue with the Sphinx documentation on the gem5 website by changing a permalink.