### PR TITLE
website: update building documentation

### DIFF
--- a/_pages/documentation/general_docs/building/index.md
+++ b/_pages/documentation/general_docs/building/index.md
@@ -161,6 +161,9 @@ where `{ISA}` is the target (guest) Instruction Set Architecture, and
 for parallelization of compilation with `{cpus}` specifying the number of
 threads. A single-threaded compilation from scratch can take up to 2 hours on
 some systems. We therefore strongly advise allocating more threads if possible.
+However, compilation of gem5 is compute and memory intensive and increasing the
+number of threads also increases memory usage. If using a machine with less
+memory, it is recommended to use fewer threads (e.g. `-j 1` or `-j 2`).
 
 The valid ISAs are:
 

--- a/_pages/documentation/general_docs/common-errors.md
+++ b/_pages/documentation/general_docs/common-errors.md
@@ -8,6 +8,25 @@ permalink: /documentation/general_docs/common-errors/
 
 Here are some common issues that users run into when using gem5, and information on how to fix them on how to fix them.
 
+## Build errors
+
+If your gem5 compilation fails with the following message:
+
+```txt
+[    LINK]  -> ALL/gem5.opt
+collect2: fatal error: ld terminated with signal 9 [Killed]
+compilation terminated.
+scons: *** [build/ALL/gem5.opt] Error 1
+scons: building terminated because of errors.
+```
+
+This indicates that your machine has run out of memory while trying to build
+gem5 and has killed the process as a result.
+If this occurs, try compiling gem5 with fewer threads, as this will consume
+less memory.
+If there are other processes using large amounts of memory on your system, try
+building gem5 when more memory is available.
+
 ## Segmentation Fault
 
 A segfault error can occur and will output to the terminal like the following:

--- a/_pages/getting_started.md
+++ b/_pages/getting_started.md
@@ -22,6 +22,8 @@ git clone https://github.com/gem5/gem5
 
 After cloning the source code, you can build gem5 by using [`scons`](https://scons.org/).
 Building gem5 can take anywhere from a few minutes on a large server to 45 minutes on a laptop.
+Building gem5 is compute and memory intensive and using additional threads causes the build process to consume more memory.
+It is therefore recommended to use fewer threads if building gem5 on a lower end machine (e.g. -j 1 or -j 2).
 gem5 must be built on a Unix platform.
 Linux is tested on every commit, and some people have been able to use MacOS as well, though it is not regularly tested.
 It is strongly suggested to *not* try to compile gem5 when running on a virtual machine.


### PR DESCRIPTION
This commit modifies the documentation for building gem5 to mention using fewer threads when building on a system with less memory.