### PR TITLE
website: update ISCA 2024 tutorial speakers, content

### DIFF
--- a/_pages/community/events/isca-2024.md
+++ b/_pages/community/events/isca-2024.md
@@ -14,9 +14,10 @@ The tutorial will provide an introduction to gem5 and its use in research and te
 ### Presenters
 
 * [Jason Lowe-Power](https://cs.ucdavis.edu/directory/jason-lowe-power)
+* [Matthew Poremba](https://scholar.google.com/citations?user=4_07_e0AAAAJ&hl=en)
+* [Vishnu Ramadas](https://pages.cs.wisc.edu/~ramadas/)
 * [Matt Sinclair](https://pages.cs.wisc.edu/~sinclair/)
 * [Alen Sabu](https://alenks.github.io/)
-* [Vishnu Ramadas](https://pages.cs.wisc.edu/~ramadas/)
 
 ### Preliminary outline
 
@@ -44,7 +45,7 @@ conclude with a tutorial on the gem5 GPU models, as this was a common request at
     - Writing a simple SimObject.
     - Creating your own component, extending from the stdlib.
     - Running simulations using your SimObject/component.
-* **Running ML workloads in PyTorch/TensorFlow in gem5** -- [2 hours]
+* **Running ML workloads in PyTorch in gem5** -- [2 hours]
     - How support works in gem5
     - Running pre-built example(s)
     - Creating checkpoints and restoring from them


### PR DESCRIPTION
Update ISCA 2024 tutorial speakers to include AMD speaker.

Update GPU content portion of tutorial to focus on PyTorch specifically, instead of either PyTorch or TensorFlow -- currently PyTorch is better supported and tested.