### PR TITLE
website: update Python and ubuntu minimum versions

### DIFF
--- a/_pages/documentation/general_docs/building/index.md
+++ b/_pages/documentation/general_docs/building/index.md
@@ -80,31 +80,6 @@ sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/c
 sudo update-alternatives --config clang-format
 ```
 
-### Setup on Ubuntu 20.04 (gem5 >= v21.0)
-
-If compiling gem5 on Ubuntu 20.04, or related Linux distributions, you may
-install all these dependencies using APT:
-
-```bash
-sudo apt install build-essential git m4 scons zlib1g zlib1g-dev \
-    libprotobuf-dev protobuf-compiler libprotoc-dev libgoogle-perftools-dev \
-    python3-dev python-is-python3 libboost-all-dev pkg-config gcc-10 g++-10 \
-    python3-tk clang-format-18
-```
-
-You may need to configure `clang-format-18` as the default
-`clang-format` for your system.
-
-```bash
-# Configure clang-format-18 and git-clang-format-18 as the system defaults.
-sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 180 \
-        --slave /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-18 \
-        --slave /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-18
-
-# [Optional] Add other alternative versions, and select version 18 as the default version.
-sudo update-alternatives --config clang-format
-```
-
 ### Docker
 
 For users struggling to setup an environment to build and run gem5, we provide
@@ -119,6 +94,9 @@ Ubuntu 24.04 with minimum dependencies:
 [ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0](
 https://ghcr.io/gem5/ubuntu-24.04_min-dependencies:v24-0)
 ([source Dockerfile](https://github.com/gem5/gem5/blob/v24.0.0.0/util/dockerfiles/ubuntu-24.04_min-dependencies/Dockerfile)).
+
+The following older images are intended for older gem5 releases whose tags
+match the image tags.
 
 Ubuntu 22.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-22.04_all-dependencies:v23-0](
@@ -141,10 +119,10 @@ To obtain a docker image:
 docker pull <image>
 ```
 
-E.g., for Ubuntu 20.04 with all optional dependencies:
+E.g., for Ubuntu 24.04 with all optional dependencies:
 
 ```bash
-docker pull ghcr.io/gem5/ubuntu-20.04_all-dependencies:v23-0
+docker pull ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0
 ```
 
 Then, to work within this environment, we suggest using the following:
@@ -155,7 +133,7 @@ docker run -u $UID:$GID --volume <gem5 directory>:/gem5 --rm -it <image>
 
 Where `<gem5 directory>` is the full path of the gem5 in your file system, and
 `<image>` is the image pulled (e.g.,
-ghcr.io/gem5/ubuntu-22.04_all-dependencies:v23-0`).
+`ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0`).
 
 From this environment, you will be able to build and run gem5 from the `/gem5`
 directory.

--- a/_pages/documentation/general_docs/building/index.md
+++ b/_pages/documentation/general_docs/building/index.md
@@ -18,9 +18,8 @@ dependencies are installed**. We ensure that gem5 is compilable with both gcc
 and clang (see [Dependencies](#dependencies)  below for compiler version
 information).
 
-As of gem5 21.0, **we support building and running gem5 with Python 3.6+
-only**. gem5 20.0 was our last version of gem5 to provide support for Python
-2.
+We support building and running gem5 with Python 3.10 or newer only. gem5
+20.0 was our last version of gem5 to provide support for Python 2.
 
 If running gem5 in a suitable OS/environment is not possible, we have provided
 pre-prepared [Docker](https://www.docker.com/) images which may be used to
@@ -36,8 +35,8 @@ support up to gcc Version 13.
 Clang 16 (inclusive).
 * **SCons** : gem5 uses SCons as its build environment. SCons 3.0 or greater
 must be used.
-* **Python 3.6+** : gem5 relies on Python development libraries. gem5 can be
-compiled and run in environments using Python 3.6+.
+* **Python 3.10+** : gem5 relies on Python development libraries. gem5 can be
+compiled and run in environments using Python 3.10+.
 * **protobuf 2.1+** (Optional): The protobuf library is used for trace
 generation and playback.
 * **Boost** (Optional): The Boost library is a set of general purpose C++
@@ -83,7 +82,8 @@ sudo update-alternatives --config clang-format
 ### Docker
 
 For users struggling to setup an environment to build and run gem5, we provide
-the following Docker Images:
+the following Docker images. For current gem5 checkouts, use an image with
+Python 3.10 or newer.
 
 Ubuntu 24.04 with all optional dependencies:
 [ghcr.io/gem5/ubuntu-24.04_all-dependencies:v24-0](

--- a/_pages/documentation/learning_gem5/part1/part1_1_building.md
+++ b/_pages/documentation/learning_gem5/part1/part1_1_building.md
@@ -66,9 +66,10 @@ sudo apt install build-essential git m4 scons zlib1g zlib1g-dev libprotobuf-dev 
     sudo apt install scons
     ```
 
-4.  Python 3.6+
-    :   gem5 relies on the Python development libraries. To install
-        these on Ubuntu use
+4.  Python 3.10+
+    :   gem5 relies on the Python development libraries. On Ubuntu, install
+        the development headers for Python 3.10 or newer. On distributions
+        where `python3` is Python 3.10 or newer, use
 
     ```bash
     sudo apt install python3-dev

--- a/_pages/documentation/learning_gem5/part1/part1_3_more_complex_config.md
+++ b/_pages/documentation/learning_gem5/part1/part1_3_more_complex_config.md
@@ -773,7 +773,7 @@ configuration script is just Python, you can use the Python libraries
 that support argument parsing. Although pyoptparse is officially
 deprecated, many of the configuration scripts that ship with gem5 use it
 instead of pyargparse since gem5's minimum Python version used to be
-2.5. The minimum Python version is now 3.6, so Python's argparse is a better
+2.5. The minimum Python version is now 3.10, so Python's argparse is a better
 option when writing new scripts that don't need to interact with the
 current gem5 scripts. To get started using :pyoptparse, you can consult
 the online Python documentation.


### PR DESCRIPTION
- The new Python minimum is now 3.10.
- The building documents were still referencing old (EOL) Ubuntu versions. This was updated. The supported Ubuntu versions are 22.04 and 24.04.